### PR TITLE
Send tools argument to llm chat

### DIFF
--- a/lib/LLM/Functions.rakumod
+++ b/lib/LLM/Functions.rakumod
@@ -45,7 +45,7 @@ multi reallyflat(+@list) {
 # LLM configuration
 #===========================================================
 
-my @mustPassConfKeys = <name prompts examples temperature max-tokens stop-tokens api-key api-user-id base-url>;
+my @mustPassConfKeys = <name prompts examples temperature max-tokens stop-tokens api-key api-user-id base-url tools>;
 my @mustPassConfKeysExt = @mustPassConfKeys.push('model');
 
 #| LLM configuration creation and retrieval.


### PR DESCRIPTION
Hi Anton,

It seems that the "tools" argument is not sent to the Gemini API.
Adding `tools` here allows `llm-chat(...tools => ...)` to work when I send something like:
```
llm-chat( ... tools => [ %( functionDeclarations => [ ... ] ] )
```

thanks
Brian
